### PR TITLE
use forwarded port 2022 for SSH

### DIFF
--- a/deployment/ansible-playbooks/group_vars/cfg_cloudservers_development
+++ b/deployment/ansible-playbooks/group_vars/cfg_cloudservers_development
@@ -1,7 +1,7 @@
 # provide the ssh connection details that Ansible needs
 # to connect to our Vagrant development boxes
 
-ansible_ssh_port: 2222
+ansible_ssh_port: 2022
 ansible_ssh_user: vagrant
 ansible_sudo_pass: vagrant
 

--- a/deployment/ansible-playbooks/group_vars/cfg_localservers_development
+++ b/deployment/ansible-playbooks/group_vars/cfg_localservers_development
@@ -1,7 +1,7 @@
 # provide the ssh connection details that Ansible needs
 # to connect to our Vagrant development boxes
 
-ansible_ssh_port: 2222
+ansible_ssh_port: 2022
 ansible_ssh_user: vagrant
 ansible_sudo_pass: vagrant
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure(2) do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "ubuntu/trusty64"
+  config.vm.network :forwarded_port, guest: 22, host: 2022, id: "ssh", auto_correct: true
 
 #  config.vm.provision "trigger", :stdout => true, :stderr => true do |trigger|
 #    trigger.fire do
@@ -24,7 +25,7 @@ Vagrant.configure(2) do |config|
 #    end
 #  end
   config.trigger.after :destroy do
-    run "ssh-keygen -R \[127.0.0.1\]:2222"
+    run "ssh-keygen -R \[127.0.0.1\]:2022"
   end
 
   # Disable automatic box update checking. If you disable this, then


### PR DESCRIPTION
To reduce conflict to other boxes use a port forwarding of SSH port to 2022.
Vagrant's first default port is 2222 and always already in use ;-)
